### PR TITLE
macOS Flicker Fix

### DIFF
--- a/rlawt.h
+++ b/rlawt.h
@@ -61,6 +61,19 @@ typedef struct {
 	int count; // entries currently allocated (0..RLAWT_MAX_POOL)
 	int back;  // current render target index
 	int front; // most recently presented surface index
+
+#ifdef RLAWT_POOL_DEBUG
+	struct {
+		int swaps;
+		int allocs;
+		int reuses;
+		int grows;
+		int stalls;
+		int failures;
+		int highWater;
+	} stats;
+	CFAbsoluteTime lastLogTime;
+#endif
 } IOSurfacePool;
 #endif
 

--- a/rlawt.h
+++ b/rlawt.h
@@ -46,6 +46,24 @@
 #	include <wglext.h>
 #endif
 
+#ifdef __APPLE__
+#define RLAWT_MAX_POOL 8
+
+typedef struct {
+	IOSurfaceRef surface;
+	CGFloat scale;
+	GLuint tex;
+	GLuint fbo;
+} IOSurfaceEntry;
+
+typedef struct {
+	IOSurfaceEntry entries[RLAWT_MAX_POOL];
+	int count; // entries currently allocated (0..RLAWT_MAX_POOL)
+	int back;  // current render target index
+	int front; // most recently presented surface index
+} IOSurfacePool;
+#endif
+
 typedef struct {
 	JAWT awt;
 	JAWT_DrawingSurface *ds;
@@ -53,13 +71,8 @@ typedef struct {
 
 #ifdef __APPLE__
 	CALayer *layer;
-	IOSurfaceRef buffer[2];
-	CGFloat bufferScale[2];
 	CGLContextObj context;
-
-	GLuint tex[2];
-	GLuint fbo[2];
-	int back;
+	IOSurfacePool pool;
 
 	int offsetX;
 	int offsetY;

--- a/rlawt_mac.m
+++ b/rlawt_mac.m
@@ -109,9 +109,41 @@ static void propsPutInt(CFMutableDictionaryRef props, const CFStringRef key, int
 	CFRelease(boxedValue);
 }
 
-static bool rlawtCreateIOSurface(JNIEnv *env, AWTContext *ctx) {
-	CGFloat scale = ctx->layer.superlayer.contentsScale;
-	CGSize size = ctx->layer.frame.size;
+// -- IOSurfacePool helpers --
+
+static void poolInit(IOSurfacePool *pool) {
+	memset(pool, 0, sizeof(*pool));
+	GLuint textures[RLAWT_MAX_POOL], framebuffers[RLAWT_MAX_POOL];
+	glGenTextures(RLAWT_MAX_POOL, textures);
+	glGenFramebuffers(RLAWT_MAX_POOL, framebuffers);
+	for (int i = 0; i < RLAWT_MAX_POOL; i++) {
+		pool->entries[i].tex = textures[i];
+		pool->entries[i].fbo = framebuffers[i];
+	}
+}
+
+static void poolDestroy(IOSurfacePool *pool) {
+	for (int i = 0; i < RLAWT_MAX_POOL; i++) {
+		glDeleteTextures(1, &pool->entries[i].tex);
+		glDeleteFramebuffers(1, &pool->entries[i].fbo);
+		if (pool->entries[i].surface) {
+			CFRelease(pool->entries[i].surface);
+		}
+	}
+}
+
+static bool poolEntryMatchesSize(IOSurfaceEntry *entry, CALayer *layer) {
+	if (!entry->surface) return false;
+	CGFloat scale = entry->scale;
+	CGSize size = layer.frame.size;
+	return IOSurfaceGetWidth(entry->surface) == (size_t)(size.width * scale)
+		&& IOSurfaceGetHeight(entry->surface) == (size_t)(size.height * scale)
+		&& layer.superlayer.contentsScale == scale;
+}
+
+static bool poolCreateSurface(JNIEnv *env, IOSurfaceEntry *entry, CALayer *layer, CGLContextObj cglCtx) {
+	CGFloat scale = layer.superlayer.contentsScale;
+	CGSize size = layer.frame.size;
 	size.width *= scale;
 	size.height *= scale;
 
@@ -127,20 +159,20 @@ static bool rlawtCreateIOSurface(JNIEnv *env, AWTContext *ctx) {
 		rlawtThrow(env, "unable to create io surface");
 		return false;
 	}
-	
+
 	const GLuint target = GL_TEXTURE_RECTANGLE;
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(target, ctx->tex[ctx->back]);
+	glBindTexture(target, entry->tex);
 	CGLError err = CGLTexImageIOSurface2D(
-		ctx->context,
+		cglCtx,
 		target, GL_RGBA,
 		size.width, size.height,
 		GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
-		buf, 
+		buf,
 		0);
 	glBindTexture(target, 0);
-	glBindFramebuffer(GL_FRAMEBUFFER, ctx->fbo[ctx->back]);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, target, ctx->tex[ctx->back], 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, entry->fbo);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, target, entry->tex, 0);
 
 	if (err != kCGLNoError) {
 		rlawtThrowCGLError(env, "unable to bind io surface to texture", err);
@@ -155,15 +187,37 @@ static bool rlawtCreateIOSurface(JNIEnv *env, AWTContext *ctx) {
 		goto freeSurface;
 	}
 
-	if (ctx->buffer[ctx->back]) {
-		CFRelease(ctx->buffer[ctx->back]);
+	if (entry->surface) {
+		CFRelease(entry->surface);
 	}
-	ctx->buffer[ctx->back] = buf;
-	ctx->bufferScale[ctx->back] = scale;
+	entry->surface = buf;
+	entry->scale = scale;
 	return true;
 freeSurface:
 	CFRelease(buf);
 	return false;
+}
+
+static int poolNextBack(IOSurfacePool *pool) {
+	// Find any non-front surface the compositor isn't using
+	for (int i = 0; i < pool->count; i++) {
+		if (i == pool->front) continue;
+		if (pool->entries[i].surface && !IOSurfaceIsInUse(pool->entries[i].surface)) {
+			return i;
+		}
+	}
+
+	// Grow pool if nothing was available
+	if (pool->count < RLAWT_MAX_POOL) {
+		return pool->count++;
+	}
+
+	// Pool full, all in use -- evict first non-front entry.
+	// count >= 2 is guaranteed here (pool grows on first swap), so this always finds one.
+	for (int i = 0; i < pool->count; i++) {
+		if (i != pool->front) return i;
+	}
+	return 0; // unreachable
 }
 
 JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_createGLContext(JNIEnv *env, jobject self) {
@@ -215,8 +269,7 @@ JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_createGLContext(JNIEnv
 		goto freeContext;
 	}
 
-	glGenTextures(2, &ctx->tex[0]);
-	glGenFramebuffers(2, &ctx->fbo[0]);
+	poolInit(&ctx->pool);
 
 	dispatch_sync(dispatch_get_main_queue(), ^{
 		RLLayer *layer = [[RLLayer alloc] init];
@@ -237,7 +290,8 @@ JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_createGLContext(JNIEnv
 			dsi->bounds.height);
 	});
 
-	if (!rlawtCreateIOSurface(env, ctx)) {
+	ctx->pool.count = 1;
+	if (!poolCreateSurface(env, &ctx->pool.entries[0], ctx->layer, ctx->context)) {
 		goto freeContext;
 	}
 
@@ -253,15 +307,10 @@ freeDSI:
 }
 
 void rlawtContextFreePlatform(JNIEnv *env, AWTContext *ctx) {
+	poolDestroy(&ctx->pool);
 	CGLSetCurrentContext(NULL);
 	if (ctx->context) {
 		CGLDestroyContext(ctx->context);
-	}
-	if (ctx->buffer[0]) {
-		CFRelease(ctx->buffer[0]);
-	}
-	if (ctx->buffer[1]) {
-		CFRelease(ctx->buffer[1]);
 	}
 	if (ctx->layer) {
 		dispatch_sync(dispatch_get_main_queue(), ^{
@@ -300,20 +349,26 @@ JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_swapBuffers(JNIEnv *en
 	}
 
 	glFlush();
+
+	IOSurfacePool *pool = &ctx->pool;
+
+	// Present the current back buffer
+	pool->front = pool->back;
 	RLLayer *rlLayer = (RLLayer*) ctx->layer;
-	rlLayer->newScale = ctx->bufferScale[ctx->back];
+	rlLayer->newScale = pool->entries[pool->front].scale;
 	[rlLayer performSelectorOnMainThread:
 		@selector(displayIOSurface:)
-		withObject: (id)(ctx->buffer[ctx->back])
+		withObject: (id)(pool->entries[pool->front].surface)
 		waitUntilDone: true];
-	
-	ctx->back ^= 1;
 
-	if (!ctx->buffer[ctx->back]
-		|| IOSurfaceGetWidth(ctx->buffer[ctx->back]) != (size_t) (ctx->layer.frame.size.width * ctx->bufferScale[ctx->back])
-		|| IOSurfaceGetHeight(ctx->buffer[ctx->back]) != (size_t) (ctx->layer.frame.size.height * ctx->bufferScale[ctx->back])
-		|| ctx->layer.superlayer.contentsScale != ctx->bufferScale[ctx->back]) {
-		if (!rlawtCreateIOSurface(env, ctx)) {
+	// Find a free surface for the next frame
+	pool->back = poolNextBack(pool);
+	IOSurfaceEntry *back = &pool->entries[pool->back];
+
+	// Create/recreate surface if needed (new slot, wrong size, or still held by compositor)
+	if (!poolEntryMatchesSize(back, ctx->layer)
+		|| IOSurfaceIsInUse(back->surface)) {
+		if (!poolCreateSurface(env, back, ctx->layer, ctx->context)) {
 			return;
 		}
 	}
@@ -325,7 +380,10 @@ JNIEXPORT jint JNICALL Java_net_runelite_rlawt_AWTContext_getFramebuffer(JNIEnv 
 		return 0;
 	}
 
-	return ctx->fbo[ctx->back ^ front];
+	if (front) {
+		return ctx->pool.entries[ctx->pool.front].fbo;
+	}
+	return ctx->pool.entries[ctx->pool.back].fbo;
 }
 
 #endif

--- a/rlawt_mac.m
+++ b/rlawt_mac.m
@@ -111,6 +111,12 @@ static void propsPutInt(CFMutableDictionaryRef props, const CFStringRef key, int
 
 // -- IOSurfacePool helpers --
 
+#ifdef RLAWT_POOL_DEBUG
+#define POOL_STAT(pool, field) ((pool)->stats.field++)
+#else
+#define POOL_STAT(pool, field) ((void)0)
+#endif
+
 static void poolInit(IOSurfacePool *pool) {
 	memset(pool, 0, sizeof(*pool));
 	GLuint textures[RLAWT_MAX_POOL], framebuffers[RLAWT_MAX_POOL];
@@ -120,6 +126,9 @@ static void poolInit(IOSurfacePool *pool) {
 		pool->entries[i].tex = textures[i];
 		pool->entries[i].fbo = framebuffers[i];
 	}
+#ifdef RLAWT_POOL_DEBUG
+	pool->lastLogTime = CFAbsoluteTimeGetCurrent();
+#endif
 }
 
 static void poolDestroy(IOSurfacePool *pool) {
@@ -203,22 +212,55 @@ static int poolNextBack(IOSurfacePool *pool) {
 	for (int i = 0; i < pool->count; i++) {
 		if (i == pool->front) continue;
 		if (pool->entries[i].surface && !IOSurfaceIsInUse(pool->entries[i].surface)) {
+			POOL_STAT(pool, reuses);
 			return i;
 		}
 	}
 
 	// Grow pool if nothing was available
 	if (pool->count < RLAWT_MAX_POOL) {
-		return pool->count++;
+		int idx = pool->count++;
+		POOL_STAT(pool, grows);
+#ifdef RLAWT_POOL_DEBUG
+		if (pool->count > pool->stats.highWater) {
+			pool->stats.highWater = pool->count;
+		}
+#endif
+		return idx;
 	}
 
 	// Pool full, all in use -- evict first non-front entry.
 	// count >= 2 is guaranteed here (pool grows on first swap), so this always finds one.
 	for (int i = 0; i < pool->count; i++) {
-		if (i != pool->front) return i;
+		if (i != pool->front) {
+			POOL_STAT(pool, stalls);
+			return i;
+		}
 	}
 	return 0; // unreachable
 }
+
+#ifdef RLAWT_POOL_DEBUG
+static void poolLogStats(IOSurfacePool *pool) {
+	CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+	if (now - pool->lastLogTime < 60.0) return;
+
+	NSLog(@"IOSurfacePool: %d swaps, %d allocs, pool %d/%d (hw %d), %d reuse, %d grow, %d stall, %d fail",
+		pool->stats.swaps,
+		pool->stats.allocs,
+		pool->count,
+		RLAWT_MAX_POOL,
+		pool->stats.highWater,
+		pool->stats.reuses,
+		pool->stats.grows,
+		pool->stats.stalls,
+		pool->stats.failures);
+
+	memset(&pool->stats, 0, sizeof(pool->stats));
+	pool->stats.highWater = pool->count;
+	pool->lastLogTime = now;
+}
+#endif
 
 JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_createGLContext(JNIEnv *env, jobject self) {
 	AWTContext *ctx = rlawtGetContext(env, self);
@@ -361,6 +403,8 @@ JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_swapBuffers(JNIEnv *en
 		withObject: (id)(pool->entries[pool->front].surface)
 		waitUntilDone: true];
 
+	POOL_STAT(pool, swaps);
+
 	// Find a free surface for the next frame
 	pool->back = poolNextBack(pool);
 	IOSurfaceEntry *back = &pool->entries[pool->back];
@@ -369,9 +413,15 @@ JNIEXPORT void JNICALL Java_net_runelite_rlawt_AWTContext_swapBuffers(JNIEnv *en
 	if (!poolEntryMatchesSize(back, ctx->layer)
 		|| IOSurfaceIsInUse(back->surface)) {
 		if (!poolCreateSurface(env, back, ctx->layer, ctx->context)) {
+			POOL_STAT(pool, failures);
 			return;
 		}
+		POOL_STAT(pool, allocs);
 	}
+
+#ifdef RLAWT_POOL_DEBUG
+	poolLogStats(pool);
+#endif
 }
 
 JNIEXPORT jint JNICALL Java_net_runelite_rlawt_AWTContext_getFramebuffer(JNIEnv *env, jobject self, jboolean front) {


### PR DESCRIPTION
This moves the macOS implementation from a two buffer approach to a pool of buffers, this is unfortunately required because the macOS compositor seems to keep a reference to the IOSurface presented via CALayer's contents after the contents have changed - resulting in the compositor using a buffer that is partially rendered, this appears to become more noticeable past 60 FPS.

Fixes https://github.com/runelite/runelite/issues/19369 